### PR TITLE
feat: Add related content links to blog posts

### DIFF
--- a/content/resources/d3/projections/index.md
+++ b/content/resources/d3/projections/index.md
@@ -1,9 +1,10 @@
 +++
 body_classes = "font-light font-sans content post mb-6 text-base md:text-lg leading-relaxed"
 categories = ["resource"]
+keywords = ["d3", "map", "projections"]
 codeexample = ""
 date = "2019-09-02T23:00:00+00:00"
-description = ""
+description = "Learn all the things that are important about projections in d3."
 external_css = []
 external_libs = []
 images = []

--- a/content/resources/d3/svg-basics/index.md
+++ b/content/resources/d3/svg-basics/index.md
@@ -1,6 +1,7 @@
 +++
 body_classes = "font-light font-sans content post mb-6 text-base md:text-lg leading-relaxed"
 categories = ["resource"]
+keywords = ["d3", "map", "svg", "groups", "path"]
 section = "d3"
 description = "Three basic elements of SVG you should know if you want to create maps with d3. "
 images = ["https://res.cloudinary.com/civicvision/image/upload/f_auto,q_auto,w_auto,dpr_auto,c_limit/geospatial-d3/marketing/website/SVG-basics.png"]

--- a/content/resources/d3/tooltip/index.md
+++ b/content/resources/d3/tooltip/index.md
@@ -1,6 +1,7 @@
 +++
 body_classes = "font-light font-sans content post mb-6 text-base md:text-lg leading-relaxed"
 categories = ["resource"]
+keywords = ["d3", "map", "tooltip"]
 date = "2019-09-01T22:00:00+00:00"
 description = "Learn how to create tooltips in d3. This post shows you actual d3 code and adds explanations to the most important aspects of tooltips in d3 and has a demo as well. "
 external_css = ["https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.48.4/codemirror.css"]

--- a/content/resources/d3/updating-your-chart/index.md
+++ b/content/resources/d3/updating-your-chart/index.md
@@ -1,6 +1,7 @@
 +++
 body_classes = "font-light font-sans content post mb-6 text-base md:text-lg leading-relaxed"
 categories = ["resource"]
+keywords = ["d3", "map", "update"]
 codeexample = ""
 date = "2019-09-03T02:00:00+00:00"
 description = "How v5 helps clean up your updating code"

--- a/layouts/partials/related.ace
+++ b/layouts/partials/related.ace
@@ -1,0 +1,11 @@
+{{ $related := .Site.RegularPages.Related . | first 5 }}
+{{ with $related }}
+h3 See Also
+.flex.flex-col.md:flex-row
+  {{ range . }}
+  .text-xl.md:mr-4.bg-blue-darker.p-4.md:w-1/3.mb-4
+    h4.mb-2
+      a.text-white href="{{ .RelPermalink }}" {{ .Title }}
+    p.text-white {{.Description}}
+  {{ end }}
+{{ end }}

--- a/themes/civic/layouts/_default/single.ace
+++ b/themes/civic/layouts/_default/single.ace
@@ -3,6 +3,7 @@
 = content main
   .container.m-auto.px-8.md:px-4.lg:p-0 class="md:flex-row max-w-xl"
     {{.Content}}
+    {{partial "related" . }}
 = content modal
   .modal
     {{ if .Page.Params.modal }}


### PR DESCRIPTION
add keywords to the posts so that the related content snippet can pick
them up (that's the preferred way for hugo to find related content)
will be good for SEO because now we have internal links for all blog
posts