### PR TITLE
feat: Add waiting list back as the second form

### DIFF
--- a/content/_index.html
+++ b/content/_index.html
@@ -11,7 +11,43 @@ form:
   id: "1028115"
   uid: ecf915d632
   subscribe_text: Send me the free lesson!
-  after_button: Learn how to create a simple map with d3.
+  after_button: |
+    <p>Learn how to create a <b>simple map</b> with d3.</p>
+    <p><a href="#waiting_list">Get on the waiting list right away!</a></p>
+  classes:
+    button: text-xl text-white focus:outline-0 w-full bg-blue-darker block py-3 font-bold
+      hover:bg-grey-darkest focus:bg-grey-light tracking-wide px-6 
+    form: mt-4 w-full
+    fields: ""
+    error: text-red-darker mb-4
+    input: block border border-transparent focus:border-grey-light rounded
+      transition w-full focus:outline-0 bg-grey-lighter py-3 px-6 mb-4 flex-grow
+    after_button: text-base mt-4 text-center
+  data:
+    options:
+      settings:
+        after_subscribe:
+          success_message: Success! Now, you need to perform an action! Check your email!! Maybe even your SPAM folder. 
+          action: redirect
+          redirect_url: https://mappingwithd3.com/subscribe
+        return_visitor:
+          custom_content: "Check your SPAM if you have not received the course yet"
+          action: hide
+        recaptcha:
+          enabled: false
+  fields:
+  - type: text
+    name: "fields[first_name]"
+    placeholder: Your first name
+  - type: email
+    name: email_address
+    placeholder: Your email address
+
+waiting_list_form:
+  id: "881267"
+  uid: 5e5e7f8875
+  subscribe_text: Get on the waiting list!
+  after_button: Join 200 other people waiting for this course!
   classes:
     button: text-xl text-white focus:outline-0 w-full bg-blue-darker block py-3 font-bold
       hover:bg-grey-darkest focus:bg-grey-light tracking-wide px-6 
@@ -163,8 +199,9 @@ form:
   {{</ paragraph >}}
 {{</ text >}}
 {{< section class="max-w-lg m-auto">}}
-  {{< signup "Learn how to create great-looking, distraction-free maps with this online course">}}
-    {{< form >}}
+  <a name="waiting_list"></a>
+  {{< signup "Get on the waiting list to be the first to know when the course launches!">}}
+    {{< form "waiting_list_form" >}}
   {{</ signup >}}
 {{</ section >}}
 {{< section >}}


### PR DESCRIPTION
have a way for people to opt-in right away instead of needing to go
through the course, I think I lost a few that would have signed up for
the waiting list
since I want to do a few more pushes I need to add this back
add a link at the first form to the second form to encourage signup
add the number of people on the waiting list as social proof