### PR TITLE
Add fallback link to redirect to gumroad page

### DIFF
--- a/content/_index.html
+++ b/content/_index.html
@@ -205,6 +205,7 @@ waiting_list_form:
   Plans
   {{</ headline >}}
   {{< pricing >}}
+  <p>If you're having trouble with the integrated buying option <a href="/buy">click here</a></p>
   {{< course-content >}}
 {{</ section >}}
 {{< section >}}

--- a/content/buy.html
+++ b/content/buy.html
@@ -1,0 +1,5 @@
+---
+---
+<script>
+  document.location = 'https://gum.co/mappingwithd3/pre-launch';
+</script>


### PR DESCRIPTION
some users have experienced problem with the gumroad overlay. if they're
having trouble add a button for them to be redirected to gumroads page
can't use the direct link because the gumroad js would pick it up, so
need an extra page :(