### PR TITLE
feat: move repl shortcode into partial and shortcode

### DIFF
--- a/content/examples/simple-geojson-map/index.md
+++ b/content/examples/simple-geojson-map/index.md
@@ -11,7 +11,9 @@ include_js = []
 layout = "example"
 section = "d3"
 title = "Simple GeoJSON Map Example"
-
+[repl]
+repo = "milafrerichs/mapping_examples"
+file = "d3/simple-geojson-map/index.js"
 +++
 # Simple GeoJSON map
 

--- a/layouts/partials/repl.ace
+++ b/layouts/partials/repl.ace
@@ -1,0 +1,28 @@
+#code-example.w-full class="{{.classes}}"
+
+link href="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.48.4/codemirror.css" rel="stylesheet"
+script src="https://unpkg.com/d3@5.9.7/dist/d3.min.js" type="text/javascript"
+script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.48.4/codemirror.min.js" type="text/javascript"
+script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.48.4/mode/javascript/javascript.js" type="text/javascript"
+script src="{{.baseUrl | default $.Site.BaseURL }}js/repl.js" type="text/javascript"
+
+= javascript
+  function loadExample() {
+    const replCode = '{{ .code }}';
+    new JavascriptRepl({
+      target: document.querySelector('#code-example'),
+      props: {
+        files: [{name: 'index.js', content: replCode, type: 'js' }],
+        layout: '{{ .layout }}'
+      }
+    });
+  }
+  function makeDoubleDelegate(function1, function2) {
+      return function() {
+          if (function1)
+              function1();
+          if (function2)
+              function2();
+      }
+  }
+  window.onload = makeDoubleDelegate(window.onload, loadExample);

--- a/layouts/shortcodes/repl.ace
+++ b/layouts/shortcodes/repl.ace
@@ -1,28 +1,11 @@
-#code-example.w-full.min-h-full
-
-link href="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.48.4/codemirror.css" rel="stylesheet"
-script src="https://unpkg.com/d3@5.9.7/dist/d3.min.js" type="text/javascript"
-script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.48.4/codemirror.min.js" type="text/javascript"
-script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.48.4/mode/javascript/javascript.js" type="text/javascript"
-script src="{{$.Site.BaseURL}}js/repl.js" type="text/javascript"
-
-= javascript
-  function loadExample() {
-    const replCode = '{{.Page.Params.codeexample}}';
-    new JavascriptRepl({
-      target: document.querySelector('#code-example'),
-      props: {
-        files: [{name: 'index.js', content: replCode, type: 'js' }],
-        layout: 'minimal'
-      }
-    });
-  }
-  function makeDoubleDelegate(function1, function2) {
-      return function() {
-          if (function1)
-              function1();
-          if (function2)
-              function2();
-      }
-  }
-  window.onload = makeDoubleDelegate(window.onload, loadExample);
+{{ $code := "" }}
+{{ if isset .Page.Params "repl" }}
+  {{ $urlPre := "https://api.github.com/repos/" }}
+  {{ $gistJ := getJSON $urlPre $.Page.Params.repl.repo "/contents/" $.Page.Params.repl.file }}
+  {{ $code = $gistJ.content | base64Decode}}
+{{else}}
+  {{ $code = .Page.Params.codeexample}}
+{{end}}
+{{ $layout := (.Get "layout") | default "minimal" }}
+{{ $classes := (.Get "classes") | default "min-h-full" }}
+{{partial "repl" (dict "code" $code "baseUrl" $.Site.BaseURL "layout" $layout "classes" $classes ) }}


### PR DESCRIPTION
now we can use both and add a way to parse a github file instead of
adding the code to the frontmatter
this will make it easier to maintain the code and get better
highlighting for myself while editing the examples and tutorials
and I get the extra benefit of having them inside a github repo